### PR TITLE
Use predefined constants

### DIFF
--- a/src/3com.c
+++ b/src/3com.c
@@ -113,7 +113,7 @@ uint32_t eth_cycle_count;
 extern int ld_die_rq;
 
 // Linux tuntap interface
-char ether_iface[30] = "ldtap";
+char ether_iface[IFNAMSIZ] = "ldtap";
 unsigned char ether_addr[6] = {0x00,0x02,0x9C,0x55,0x89,0xC6};
 int pkt_count = 0;
 int ether_fd = -1;
@@ -186,7 +186,7 @@ uint32_t ether_rx_pkt(){
 #if !defined (USES_ETHER_CODE) && defined (HAVE_NET_BPF_H)
 #define USES_ETHER_CODE "BPF"
 
-char ether_bpfn[64];
+char ether_bpfn[PATH_MAX];
 #ifdef USE_UTUN
 // For tunnel frame diverter hack
 char guest_ip_addr[32] = "";
@@ -979,7 +979,7 @@ int yaml_network_mapping_loop(yaml_parser_t *parser){
       }else{
 	strncpy(value,(const char *)event.data.scalar.value,128);
         if(strcmp(key,"interface") == 0){
-	  strncpy(ether_iface,value,30);
+	  strncpy(ether_iface,value,sizeof(ether_iface));
 	  logmsgf(LT_3COM,0,"Using 3Com Ethernet interface %s\n",ether_iface);	  
 	  goto value_done;
 	}

--- a/src/tapemaster.c
+++ b/src/tapemaster.c
@@ -32,6 +32,7 @@
 #include <string.h>
 #include <strings.h>
 #include <dirent.h>
+#include <limits.h>
 
 #include "ld.h"
 #include "nubus.h"
@@ -44,7 +45,7 @@ int tape_fm = 0;             // At filemark
 int tape_reclen = 0;         // Tape record length
 int tape_error = 0;          // Tapemaster error code
 uint8_t tape_block[64*1024]; // Tape block buffer
-char tape_fn[32] = "None";   // Current tape filename
+char tape_fn[PATH_MAX] = "None";   // Current tape filename
 int tape_file_sel = -1;      // Tape file selector
 
 // Structures and such
@@ -192,7 +193,7 @@ int tapemaster_open_next(){
   if(tape_fd != -1){
     logmsgf(LT_TAPEMASTER,1,"TM: Closing file %s\n",tape_fn);
     close(tape_fd);
-    strncpy(tape_fn,"None",32);
+    strncpy(tape_fn,"None",sizeof(tape_fn));
     tape_fd = -1;
     tape_bot = 0;
     tape_eot = 0;
@@ -209,19 +210,19 @@ int tapemaster_open_next(){
     tape_file_sel = -1;
     return(-1);
   }else{
-    char fn[256] = "./tapes/";
+    char fn[PATH_MAX] = "./tapes/";
     if(n == 0){ tape_file_sel = -1; return(-1); } // No files
     if(tape_file_sel >= n){ tape_file_sel = 0; }
     // Attempt open
-    strncat(fn,namelist[tape_file_sel]->d_name,255);
+    strncat(fn,namelist[tape_file_sel]->d_name,PATH_MAX);
     tape_fd = open(fn,O_RDWR);
     if(tape_fd < 0){
-      char emsg[256] = "open(): ";
-      strncat(emsg,fn,255);
+      char emsg[PATH_MAX+8] = "open(): ";
+      strncat(emsg,fn,PATH_MAX);
       perror(emsg);
       tape_fd = -1;
     }else{
-      strncpy(tape_fn,namelist[tape_file_sel]->d_name,32);
+      strncpy(tape_fn,namelist[tape_file_sel]->d_name,PATH_MAX);
       logmsgf(LT_TAPEMASTER,1,"TM: Opened file %s\n",tape_fn);
       tape_bot = 1;
       tape_eot = 0;

--- a/src/vcmem.c
+++ b/src/vcmem.c
@@ -25,6 +25,9 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <strings.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
 
 #include "ld.h"
 #include "nubus.h"
@@ -45,6 +48,22 @@ extern uint8_t mouse_io_ring[2][0x100];
 extern uint8_t mouse_io_ring_top[2],mouse_io_ring_bottom[2];
 
 // Functions
+void read_vcmem_rom(){
+  int rom_fd = open("roms/VCMEM.ROM",O_RDONLY);
+  if(rom_fd < 0){
+    perror("VCMEM:open");
+    exit(-1);
+  }else{
+    ssize_t rv=0;
+    rv = read(rom_fd,VCMEM_ROM,sizeof(VCMEM_ROM));
+    if(rv != sizeof(VCMEM_ROM)){
+      perror("VCMEM:read");
+      exit(-1);
+    }
+    close(rom_fd);
+  }
+}
+
 void vcmem_init(int vn,int slot){
   vcS[vn].Card = slot;
   vcS[vn].cycle_count = 0;


### PR DESCRIPTION
rather than random fixnums, for sizes of filenames, hostnames, interfaces, memory etc.